### PR TITLE
feat: Inclui e configura a parcial messages

### DIFF
--- a/product/views.py
+++ b/product/views.py
@@ -1,8 +1,10 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect, get_object_or_404
+from django.urls import reverse
 from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
 from django.views import View
 from django.http import HttpResponse
+from django.contrib import messages
 from . import models
 
 # TODO: Remove get() method after tests
@@ -23,7 +25,22 @@ class ProductDetail(DetailView):
 
 class AddToCart(View):
     def get(self, *args, **kwargs):
-        return HttpResponse('Adicionar ao carrinho')
+        http_referer = self.request.META.get(
+            'HTTP_REFERER',
+            reverse('product:list')
+        )
+        vid = self.request.GET.get('vid')
+
+        if not vid:
+            messages.error(
+                self.request,
+                'ERRO: O produto não existe!'
+            )
+            return redirect(http_referer)
+
+        variation = get_object_or_404(models.Variation, id=vid)
+
+        return HttpResponse(f'{variation.product}')
 
 
 class RemoveFromCart(View):

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     {% include "partials/_nav.html" %}
 
     <main class="container mt-4 mb-4">
+        {% include "partials/_messages.html" %}
         {% block content %}{% endblock content %}
     </main>
 


### PR DESCRIPTION
Inclusão do template parcial `_messages.html` no arquivo base que é renderizado na view `AddToCart` do produto por meio do módulo `messages` de `django.contrib`. 

Para um primeiro teste e prevenção de erros relacionados à ausência de um determinado produto, foi criada a variável <a href="https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Headers/Referer">`http_referer`</a> para recuperar a url anterior na qual a solicitação atual de adicionar um produto ao carrinho foi feita. 

Utilizando o parâmetro `vid` armazenado em uma variável de mesmo nome (por meio de um método `get()`), validamos esse parâmetro e, caso não esteja presente, redirecionamos o usuário de volta à página inicial com auxílio do referer citado anteriormente, renderizando uma mensagem de erro usando o framework de mensagens do Django.

Caso o `vid` estiver presente, a variável `variation` tenta recuperar a instância da model `Variation` no banco de dados com auxílio do shortcut `get_object_or_404`, retornando uma response que exibe o nome do produto. Isso é feito com base no ID fornecido no parâmetro 'vid'. Porém, se o valor do `vid` estiver presente na url mas não existir no banco de `Variation`, retorna o erro 404.


